### PR TITLE
Update config file error handling.

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spf13/viper"
 
 	"net/http"
+	"net/url"
 )
 
 type TokenRequest struct {
@@ -61,13 +62,21 @@ fmeserver login https://my-fmeserver.internal --token 5937391ad3a87f19ba14dc6082
 
 # Login to an FME Server using a passed in user and password
 fmeserver login https://my-fmeserver.internal --user admin --password passw0rd`,
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		return nil
+	},
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
 			rootCmd.SilenceUsage = false
 			return errors.New("requires a URL")
 		}
-		if !(strings.HasPrefix(args[0], "http") || strings.HasPrefix(args[0], "https")) {
-			return errors.New("url must start with http or https")
+		urlErrorMsg := "invalid FME Server URL specified. URL should be of the form https://myfmeserverhostname.com"
+		url, err := url.ParseRequestURI(args[0])
+		if err != nil {
+			return fmt.Errorf(urlErrorMsg)
+		}
+		if url.Path != "" {
+			return fmt.Errorf(urlErrorMsg)
 		}
 		return nil
 	},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"path"
 
@@ -27,6 +28,28 @@ var rootCmd = &cobra.Command{
 	Version:       "0.4",
 	SilenceErrors: true,
 	SilenceUsage:  true,
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		// make sure the config file is set up correctly
+		_, err := os.Stat(viper.ConfigFileUsed())
+		if err != nil {
+			return fmt.Errorf("could not open the config file " + viper.ConfigFileUsed() + ". Have you called the login command? ")
+		}
+		fmeserverUrl := viper.GetString("url")
+
+		// check the fme server URL is valid
+		_, err = url.ParseRequestURI(fmeserverUrl)
+		if err != nil {
+			return fmt.Errorf("invalid FME Server url in config file " + viper.ConfigFileUsed() + ". Have you called the login command? ")
+		}
+
+		// check there is a token to use for auth
+		fmeserverToken := viper.GetString("token")
+		if fmeserverToken == "" {
+			return fmt.Errorf("no token found in config file " + viper.ConfigFileUsed() + ". Have you called the login command? ")
+		}
+
+		return nil
+	},
 	// Uncomment the following line if your bare application
 	// has an action associated with it:
 	// Run: func(cmd *cobra.Command, args []string) { },
@@ -81,8 +104,8 @@ func initConfig() {
 	//viper.AutomaticEnv() // read in environment variables that match
 
 	// If a config file is found, read it in.
-	err := viper.ReadInConfig()
-	cobra.CheckErr(err)
+	viper.ReadInConfig()
+
 }
 
 // Function for commands that provide no arguments. This will turn usage back on


### PR DESCRIPTION
Instead of doing some validation on the config file and its contents in the init, it is now done as part of the PreRun for commands. This is because for certain commands (currently just login), we don't need the config file to be set up for that command to run. Therefore we can override the PreRun function for that command to not do the validation.

This also adds a bit of error checking on the login command as well to ensure the URL entered is formatted correctly.