### PR TITLE
Add standard output flags to license refresh and request commands.

### DIFF
--- a/cmd/refreshStatus.go
+++ b/cmd/refreshStatus.go
@@ -6,24 +6,47 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
 
+type licenseRefreshStatusFlags struct {
+	outputType string
+	noHeaders  bool
+}
+
 func newRefreshStatusCmd() *cobra.Command {
-	return &cobra.Command{
+	f := licenseRefreshStatusFlags{}
+	cmd := &cobra.Command{
 		Use:   "status",
 		Short: "Check status of license refresh",
 		Long:  "Check the status of a license refresh request.",
 		Example: `
-  fmeserver license refresh status`,
+	# Output the license refresh status as a table
+	fmeserver license refresh status
+	
+	# Output the license refresh status in json
+	fmeserver license refresh status --json
+	
+	# Output just the status message
+	fmeserver license refresh status --output custom-columns=STATUS:.status --no-headers`,
 		Args: NoArgs,
-		RunE: refreshStatusRun(),
+		RunE: refreshStatusRun(&f),
 	}
+	cmd.Flags().StringVarP(&f.outputType, "output", "o", "table", "Specify the output type. Should be one of table, json, or custom-columns")
+	cmd.Flags().BoolVar(&f.noHeaders, "no-headers", false, "Don't print column headers")
+	return cmd
+
 }
 
-func refreshStatusRun() func(cmd *cobra.Command, args []string) error {
+func refreshStatusRun(f *licenseRefreshStatusFlags) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
+		// --json overrides --output
+		if jsonOutput {
+			f.outputType = "json"
+		}
+
 		// set up http
 		client := &http.Client{}
 
@@ -48,20 +71,51 @@ func refreshStatusRun() func(cmd *cobra.Command, args []string) error {
 		if err := json.Unmarshal(responseData, &result); err != nil {
 			return err
 		} else {
-			if !jsonOutput {
-				// output all values returned by the JSON in a table
+			if f.outputType == "table" {
 				t := createTableWithDefaultColumns(result)
 
-				if noHeaders {
+				if f.noHeaders {
 					t.ResetHeaders()
 				}
 				fmt.Fprintln(cmd.OutOrStdout(), t.Render())
-			} else {
+
+			} else if f.outputType == "json" {
 				prettyJSON, err := prettyPrintJSON(responseData)
 				if err != nil {
 					return err
 				}
 				fmt.Fprintln(cmd.OutOrStdout(), prettyJSON)
+			} else if strings.HasPrefix(f.outputType, "custom-columns") {
+				// parse the columns and json queries
+				columnsString := ""
+				if strings.HasPrefix(f.outputType, "custom-columns=") {
+					columnsString = f.outputType[len("custom-columns="):]
+				}
+				if len(columnsString) == 0 {
+					return errors.New("custom-columns format specified but no custom columns given")
+				}
+
+				// we have to marshal the Items array, then create an array of marshalled items
+				// to pass to the creation of the table.
+				marshalledItems := [][]byte{}
+				mJson, err := json.Marshal(result)
+				if err != nil {
+					return err
+				}
+				marshalledItems = append(marshalledItems, mJson)
+
+				columnsInput := strings.Split(columnsString, ",")
+				t, err := createTableFromCustomColumns(marshalledItems, columnsInput)
+				if err != nil {
+					return err
+				}
+				if f.noHeaders {
+					t.ResetHeaders()
+				}
+				fmt.Fprintln(cmd.OutOrStdout(), t.Render())
+
+			} else {
+				return errors.New("invalid output format specified")
 			}
 
 		}

--- a/cmd/requestStatus.go
+++ b/cmd/requestStatus.go
@@ -6,31 +6,46 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
 
+type licenseRequestStatusFlags struct {
+	outputType string
+	noHeaders  bool
+}
+
 func newLicenseRequestStatusCmd() *cobra.Command {
+	f := licenseRequestStatusFlags{}
 	cmd := &cobra.Command{
 		Use:   "status",
 		Short: "Check status of license request",
-		Long: `Check the status of a license request.
-		
-	Examples:
-	
+		Long:  "Check the status of a license request.",
+		Example: `
 	# Output the license request status as a table
 	fmeserver license request status
 	
 	# Output the license Request status in json
-	fmeserver license request status --json`,
+	fmeserver license request status --json
+	
+	# Output just the status message
+	fmeserver license request status --output custom-columns=STATUS:.status --no-headers`,
 		Args: NoArgs,
-		RunE: licenseRequestStatusRun(),
+		RunE: licenseRequestStatusRun(&f),
 	}
+	cmd.Flags().StringVarP(&f.outputType, "output", "o", "table", "Specify the output type. Should be one of table, json, or custom-columns")
+	cmd.Flags().BoolVar(&f.noHeaders, "no-headers", false, "Don't print column headers")
 	return cmd
 }
 
-func licenseRequestStatusRun() func(cmd *cobra.Command, args []string) error {
+func licenseRequestStatusRun(f *licenseRequestStatusFlags) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
+		// --json overrides --output
+		if jsonOutput {
+			f.outputType = "json"
+		}
+
 		// set up http
 		client := &http.Client{}
 
@@ -55,20 +70,51 @@ func licenseRequestStatusRun() func(cmd *cobra.Command, args []string) error {
 		if err := json.Unmarshal(responseData, &result); err != nil {
 			return err
 		} else {
-			if !jsonOutput {
-				// output all values returned by the JSON in a table
+			if f.outputType == "table" {
 				t := createTableWithDefaultColumns(result)
 
-				if noHeaders {
+				if f.noHeaders {
 					t.ResetHeaders()
 				}
 				fmt.Fprintln(cmd.OutOrStdout(), t.Render())
-			} else {
+
+			} else if f.outputType == "json" {
 				prettyJSON, err := prettyPrintJSON(responseData)
 				if err != nil {
 					return err
 				}
 				fmt.Fprintln(cmd.OutOrStdout(), prettyJSON)
+			} else if strings.HasPrefix(f.outputType, "custom-columns") {
+				// parse the columns and json queries
+				columnsString := ""
+				if strings.HasPrefix(f.outputType, "custom-columns=") {
+					columnsString = f.outputType[len("custom-columns="):]
+				}
+				if len(columnsString) == 0 {
+					return errors.New("custom-columns format specified but no custom columns given")
+				}
+
+				// we have to marshal the Items array, then create an array of marshalled items
+				// to pass to the creation of the table.
+				marshalledItems := [][]byte{}
+				mJson, err := json.Marshal(result)
+				if err != nil {
+					return err
+				}
+				marshalledItems = append(marshalledItems, mJson)
+
+				columnsInput := strings.Split(columnsString, ",")
+				t, err := createTableFromCustomColumns(marshalledItems, columnsInput)
+				if err != nil {
+					return err
+				}
+				if f.noHeaders {
+					t.ResetHeaders()
+				}
+				fmt.Fprintln(cmd.OutOrStdout(), t.Render())
+
+			} else {
+				return errors.New("invalid output format specified")
 			}
 
 		}


### PR DESCRIPTION
The `license request status` and `license refresh status` commands didn't have the same output options as other commands. This brings it in line with those.