### PR TITLE
Automatically add file extensions to backup and project download.

### DIFF
--- a/cmd/backup.go
+++ b/cmd/backup.go
@@ -70,12 +70,10 @@ func backupRun(f *backupFlags) func(cmd *cobra.Command, args []string) error {
 		client := &http.Client{}
 
 		// massage the backup file name
-		if !f.suppressFileRename {
-			if f.outputBackupFile != "" {
-				backupExtension := ".fsconfig"
-				if !strings.HasSuffix(f.outputBackupFile, backupExtension) {
-					f.outputBackupFile += backupExtension
-				}
+		if !f.suppressFileRename && f.outputBackupFile != "" {
+			backupExtension := ".fsconfig"
+			if !strings.HasSuffix(f.outputBackupFile, backupExtension) {
+				f.outputBackupFile += backupExtension
 			}
 		}
 

--- a/cmd/projects_download.go
+++ b/cmd/projects_download.go
@@ -55,12 +55,10 @@ func projectDownloadRun(f *projectsDownloadFlags) func(cmd *cobra.Command, args 
 		client := &http.Client{}
 
 		// massage the backup file name
-		if !f.suppressFileRename {
-			if f.file != "" {
-				backupExtension := ".fsproject"
-				if !strings.HasSuffix(f.file, backupExtension) {
-					f.file += backupExtension
-				}
+		if !f.suppressFileRename && f.file != "" {
+			backupExtension := ".fsproject"
+			if !strings.HasSuffix(f.file, backupExtension) {
+				f.file += backupExtension
 			}
 		}
 


### PR DESCRIPTION
Automatically adds the file extension when backing up or downloading a project. I also added a hidden flag to turn off this behavior in case someone really wants a different file extension when downloading.