### PR TITLE
Change automated login to use a password file instead of plaintext password on the command line.

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -114,7 +114,7 @@ func loginRun(f *loginFlags) func(cmd *cobra.Command, args []string) error {
 		var password string
 
 		if f.token == "" {
-			if f.user == "" && f.passwordFile == "" {
+			if f.user == "" || f.passwordFile == "" {
 				// prompt for a user and password
 				promptUser := &survey.Input{
 					Message: "Username:",


### PR DESCRIPTION
As a best practice, we shouldn't allow passwords to be passed in on the command line. This updates the CLI to accept a file containing the password instead.