### PR TITLE
Overhaul release action to digitally sign on Windows and Mac

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,25 +5,196 @@ on:
     types: [created]
 
 jobs:
-  releases-matrix:
+  build-matrix:
     name: Release Go Binary
     runs-on: ubuntu-latest
     strategy:
       matrix:
         # build and publish in parallel: linux/amd64, linux/arm64, windows/amd64, darwin/amd64, darwin/arm64
-        goos: [linux, windows, darwin]
-        goarch: [amd64, arm64]
+        os: [linux, windows, darwin]
+        arch: [amd64, arm64]
         exclude:
-          - goarch: arm64
-            goos: windows
+          - arch: arm64
+            os: windows
+        # output with a .exe extension on Windows
+        include:
+          - os: windows
+            exe-ext: ".exe"
+
     steps:
-    - uses: actions/checkout@v3
+    - name: Checkout code
+      uses: actions/checkout@v3
+    
     - name: Set APP_VERSION env
-      run: echo APP_VERSION=$(echo ${GITHUB_REF} | rev | cut -d'/' -f 1 | rev ) >> ${GITHUB_ENV}  
-    - uses: wangyoucao577/go-release-action@v1.28
+      run: echo APP_VERSION=$(echo ${GITHUB_REF} | rev | cut -d'/' -f 1 | rev ) >> ${GITHUB_ENV} 
+
+    - name: Set up Go
+      uses: actions/setup-go@v3
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        goos: ${{ matrix.goos }}
-        goarch: ${{ matrix.goarch }}
-        binary_name: "fmeserver"
-        ldflags: -X "github.com/safesoftare/fmeserver-cli/cmd.appVersion=${{ env.APP_VERSION }}"
+        go-version: 1.19
+
+    - name: Build project
+      run: |
+        export GOOS=${{ matrix.os }}
+        export GOARCH=${{ matrix.arch }}
+        go build -o fmeserver${{ matrix.exe-ext }} -ldflags="-X \"github.com/safesoftare/fmeserver-cli/cmd.appVersion=${{ env.APP_VERSION }}\""
+
+    - name: Upload artifact for later steps
+      uses: actions/upload-artifact@v3
+      with:
+        name: fmeserver-${{ matrix.os }}-${{ matrix.arch }}
+        path: fmeserver${{ matrix.exe-ext }}
+        if-no-files-found: error
+
+  sign-windows:
+    name: Sign Windows Binary
+    needs: build-matrix
+    runs-on: windows-latest
+    steps:
+    - name: Download
+      uses: actions/download-artifact@v3
+      with:
+        name: fmeserver-windows-amd64
+    
+    - name: Sign
+      env:
+        CERTPASS: ${{secrets.PROD_WIN_CERTIFICATE_PWD}}
+        SIGNCERT: ${{secrets.PROD_WIN_CERTIFICATE}}
+      run: |
+        # Create buffer from the BASE64 string of the PFX stored in the secret
+        $buffer = [System.Convert]::FromBase64String($env:SIGNCERT)
+        # Create new certificate object from the buffer and the certificate pass
+        $certificate = [System.Security.Cryptography.X509Certificates.X509Certificate2]::New($buffer, $env:CERTPASS)
+        Set-AuthenticodeSignature -HashAlgorithm SHA256 -Certificate $certificate -TimestampServer http://timestamp.digicert.com -FilePath fmeserver.exe
+    
+    - name: Reupload artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: fmeserver-windows-amd64
+        path: fmeserver.exe
+
+  sign-macosx:
+    name: Sign Mac Binaries
+    needs: build-matrix
+    runs-on: macos-11
+    strategy:
+      matrix:
+        # sign both darwin/amd64, darwin/arm64
+        os: [darwin]
+        arch: [amd64, arm64]
+    steps:
+    - name: Download
+      uses: actions/download-artifact@v3
+      with:
+        name: fmeserver-${{ matrix.os }}-${{ matrix.arch }}
+
+    - name: Codesign binaries
+      # Extract the secrets
+      env: 
+        MACOS_CERTIFICATE: ${{ secrets.PROD_MACOS_CERTIFICATE }}
+        MACOS_CERTIFICATE_PWD: ${{ secrets.PROD_MACOS_CERTIFICATE_PWD }}
+        MACOS_CERTIFICATE_NAME: ${{ secrets.PROD_MACOS_CERTIFICATE_NAME }}
+        MACOS_CI_KEYCHAIN_PWD: ${{ secrets.PROD_MACOS_CI_KEYCHAIN_PWD }}
+      run: |
+        # Turn our base64-encoded certificate back to a regular .p12 file
+        
+        echo $MACOS_CERTIFICATE | base64 --decode > certificate.p12
+
+        # We need to create a new keychain, otherwise using the certificate will prompt
+        # with a UI dialog asking for the certificate password, which we can't
+        # use in a headless CI environment
+        
+        security create-keychain -p "$MACOS_CI_KEYCHAIN_PWD" build.keychain 
+        security default-keychain -s build.keychain
+        security unlock-keychain -p "$MACOS_CI_KEYCHAIN_PWD" build.keychain
+        security import certificate.p12 -k build.keychain -P "$MACOS_CERTIFICATE_PWD" -T /usr/bin/codesign
+        security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$MACOS_CI_KEYCHAIN_PWD" build.keychain
+
+        # We finally codesign our app bundle, specifying the Hardened runtime option
+        
+        /usr/bin/codesign --force -s "$MACOS_CERTIFICATE_NAME" --options runtime fmeserver -v
+    
+    - name: "Notarize executable"
+      # Extract the secrets we defined earlier as environment variables
+      env:
+        PROD_MACOS_NOTARIZATION_APPLE_ID: ${{ secrets.PROD_MACOS_NOTARIZATION_APPLE_ID }}
+        PROD_MACOS_NOTARIZATION_TEAM_ID: ${{ secrets.PROD_MACOS_NOTARIZATION_TEAM_ID }}
+        PROD_MACOS_NOTARIZATION_PWD: ${{ secrets.PROD_MACOS_NOTARIZATION_PWD }}
+      run: |
+        # Store the notarization credentials so that we can prevent a UI password dialog
+        # from blocking the CI
+
+        echo "Create keychain profile"
+        xcrun notarytool store-credentials "notarytool-profile" --apple-id "$PROD_MACOS_NOTARIZATION_APPLE_ID" --team-id "$PROD_MACOS_NOTARIZATION_TEAM_ID" --password "$PROD_MACOS_NOTARIZATION_PWD"
+
+        # We can't notarize the executable directly, but we need to compress it as an archive.
+        # Therefore, we create a zip file containing our app bundle, so that we can send it to the
+        # notarization service
+
+        echo "Creating temp notarization archive"
+        ditto -c -k --keepParent "fmeserver" "notarization.zip"
+
+        # Here we send the notarization request to the Apple's Notarization service, waiting for the result.
+        # This typically takes a few seconds inside a CI environment, but it might take more depending on the App
+        # characteristics. Visit the Notarization docs for more information and strategies on how to optimize it if
+        # you're curious
+
+        echo "Notarize app"
+        xcrun notarytool submit "notarization.zip" --keychain-profile "notarytool-profile" --wait
+
+    - name: Reupload artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: fmeserver-${{ matrix.os }}-${{ matrix.arch }}
+        path: fmeserver
+
+  compress-files:
+    name: Compress binaries and release
+    runs-on: ubuntu-latest
+    needs: [sign-windows, sign-macosx]
+    strategy:
+      matrix:
+        # build and publish in parallel: linux/amd64, linux/arm64, windows/amd64, darwin/amd64, darwin/arm64
+        os: [linux, windows, darwin]
+        arch: [amd64, arm64]
+        exclude:
+          - arch: arm64
+            os: windows
+        # set up zip and executable extensions that differ on Windows
+        include:
+          - os: windows
+            zip-ext: zip
+            exe-ext: .exe
+            type: zip
+          - os: linux
+            zip-ext: tar.gz
+            type: tar
+          - os: darwin
+            zip-ext: tar.gz
+            type: tar
+    steps:
+    - name: Download
+      uses: actions/download-artifact@v3
+      with:
+        name: fmeserver-${{ matrix.os }}-${{ matrix.arch }}
+    
+    # zip or tar.gz the binary
+    - name: Archive Release
+      uses: thedoctor0/zip-release@0.7.1
+      with:
+        type: ${{ matrix.type }}
+        path: fmeserver${{ matrix.exe-ext }}
+        filename: fmeserver-${{ matrix.os }}-${{ matrix.arch }}.${{ matrix.zip-ext }}
+
+    - name: Calculate MD5 hash
+      run: |
+        MD5_SUM=$(md5sum fmeserver-${{ matrix.os }}-${{ matrix.arch }}.${{ matrix.zip-ext }} | cut -d ' ' -f 1)
+        echo ${MD5_SUM} >fmeserver-${{ matrix.os }}-${{ matrix.arch }}.${{ matrix.zip-ext }}.md5
+        cat fmeserver-${{ matrix.os }}-${{ matrix.arch }}.${{ matrix.zip-ext }}.md5
+
+    # Add compressed files and md5 hashes to the release
+    - uses: AButler/upload-release-assets@v2.0
+      with:
+        files: '*.md5;*.zip;*.tar.gz'
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,7 +14,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: 1.19
 


### PR DESCRIPTION
This adds digital signing for the Windows and Mac builds. I had to rewrite the pipeline completely as the action I was using before only runs on ubuntu, so it doesn't support digital signing. This will build each platform on a Linux agent, then uses a Windows and Mac agent to do the respective signing, then another Linux agent to zip and upload for the release.

The only part I haven't been able to test is the very last step. I will test after this is merged, and hopefully it works! 😄 