### PR TITLE
Output error messages from failed logins.

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -179,7 +179,8 @@ func loginRun(f *loginFlags) func(cmd *cobra.Command, args []string) error {
 				// Unmarshal responseData into a string that is the json text
 				var result map[string]interface{}
 				if err := json.Unmarshal(responseData, &result); err != nil {
-					return err
+					// if we fail to unmarshal the response, the body is not json. Return the response status
+					return errors.New(response.Status)
 				}
 
 				// if there is a message in the response, return that along with the response.Status

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -177,18 +177,15 @@ func loginRun(f *loginFlags) func(cmd *cobra.Command, args []string) error {
 					return err
 				}
 				// Unmarshal responseData into a string that is the json text
-				var result map[string]interface{}
-				if err := json.Unmarshal(responseData, &result); err != nil {
+				var responseMessage Message
+				if err := json.Unmarshal(responseData, &responseMessage); err != nil {
 					// if we fail to unmarshal the response, the body is not json. Return the response status
 					return errors.New(response.Status)
 				}
 
 				// if there is a message in the response, return that along with the response.Status
-				if result["message"] != nil {
-					return errors.New(response.Status + ": " + result["message"].(string))
-				} else {
-					return errors.New(response.Status)
-				}
+				return errors.New(response.Status + ": " + responseMessage.Message)
+
 			}
 
 			responseData, err := io.ReadAll(response.Body)


### PR DESCRIPTION
We were previously only outputting the error code on failed logins. This will also output any returned error message, which is helpful to know if the reason for the failure is because the user needs to do their first login on the Web UI.