### PR TITLE
Check if deployment parameter exists before prompting to delete.

### DIFF
--- a/cmd/deploymentparameters_delete.go
+++ b/cmd/deploymentparameters_delete.go
@@ -46,8 +46,41 @@ func deploymentParameterDeleteRun(f *deploymentParameterDeleteFlags) func(cmd *c
 		// set up http
 		client := &http.Client{}
 
+		// check if deployment parameter exists first and error if it does not
+		request, err := buildFmeFlowRequest("/fmeapiv4/deploymentparameters/"+f.name, "GET", nil)
+		if err != nil {
+			return err
+		}
+		// send the request
+		response, err := client.Do(&request)
+		if err != nil {
+			return err
+		} else if response.StatusCode != http.StatusOK {
+			// if we didn't get a 200 OK, then the deployment parameter does not exist
+			// get the JSON response and throw a new error using the message
+			responseData, err := io.ReadAll(response.Body)
+			if err == nil {
+				var responseMessage Message
+				if err := json.Unmarshal(responseData, &responseMessage); err == nil {
+					// if json output is requested, output the JSON to stdout before erroring
+					if jsonOutput {
+						prettyJSON, err := prettyPrintJSON(responseData)
+						if err == nil {
+							fmt.Fprintln(cmd.OutOrStdout(), prettyJSON)
+						} else {
+							return errors.New(response.Status)
+						}
+					}
+					return errors.New(responseMessage.Message)
+				} else {
+					return errors.New(response.Status)
+				}
+			}
+		}
+
+		// the parameter exists. Confirm deletion.
 		if !f.noprompt {
-			// prompt for a user and password
+			// prompt to confirm deletion
 			confirm := false
 			promptUser := &survey.Confirm{
 				Message: "Are you sure you want to delete the deployment parameter " + f.name + "?",
@@ -58,12 +91,12 @@ func deploymentParameterDeleteRun(f *deploymentParameterDeleteFlags) func(cmd *c
 			}
 		}
 
-		request, err := buildFmeFlowRequest("/fmeapiv4/deploymentparameters/"+f.name, "DELETE", nil)
+		request, err = buildFmeFlowRequest("/fmeapiv4/deploymentparameters/"+f.name, "DELETE", nil)
 		if err != nil {
 			return err
 		}
 
-		response, err := client.Do(&request)
+		response, err = client.Do(&request)
 		if err != nil {
 			return err
 		} else if response.StatusCode != http.StatusNoContent {

--- a/cmd/deploymentparameters_delete_test.go
+++ b/cmd/deploymentparameters_delete_test.go
@@ -2,10 +2,30 @@ package cmd
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestDeploymentParametersDelete(t *testing.T) {
+	customHttpServerHandler := func(w http.ResponseWriter, r *http.Request) {
+
+		if r.Method == "GET" {
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write([]byte(""))
+			require.NoError(t, err)
+
+		}
+		if r.Method == "DELETE" {
+			w.WriteHeader(http.StatusNoContent)
+			_, err := w.Write([]byte(""))
+			require.NoError(t, err)
+
+		}
+
+	}
+
 	paramMissingBody := `{
 		"message": "Unauthorized request by user admin due to lack of proper permissions or the object does not exist."
 	  }`
@@ -33,6 +53,7 @@ func TestDeploymentParametersDelete(t *testing.T) {
 			statusCode:      http.StatusNoContent,
 			args:            []string{"deploymentparameters", "delete", "--name", "myDep", "--no-prompt"},
 			wantOutputRegex: "^Deployment Parameter successfully deleted.[\\s]*$",
+			httpServer:      httptest.NewServer(http.HandlerFunc(customHttpServerHandler)),
 		},
 		{
 			name:        "delete parameter not found",


### PR DESCRIPTION
Previously we were prompting "Are you sure?" even if the parameter doesn't exist. This makes the user experience a little better by checking that it exists first.