### PR TITLE
Make url check more forgiving

### DIFF
--- a/cmd/deploymentparameters_delete.go
+++ b/cmd/deploymentparameters_delete.go
@@ -16,6 +16,8 @@ type deploymentParameterDeleteFlags struct {
 	noprompt bool
 }
 
+
+
 func newDeploymentParameterDeleteCmd() *cobra.Command {
 	f := deploymentParameterDeleteFlags{}
 	cmd := &cobra.Command{

--- a/cmd/deploymentparameters_delete.go
+++ b/cmd/deploymentparameters_delete.go
@@ -16,8 +16,6 @@ type deploymentParameterDeleteFlags struct {
 	noprompt bool
 }
 
-
-
 func newDeploymentParameterDeleteCmd() *cobra.Command {
 	f := deploymentParameterDeleteFlags{}
 	cmd := &cobra.Command{

--- a/cmd/functions.go
+++ b/cmd/functions.go
@@ -180,7 +180,7 @@ func checkConfigFile(requireToken bool) error {
 	// check the fme server URL is valid
 	_, err = url.ParseRequestURI(fmeflowUrl)
 	if err != nil {
-		return fmt.Errorf("invalid FME Server url in config file " + viper.ConfigFileUsed() + ". Have you called the login command? ")
+		return fmt.Errorf("invalid FME Flow url in config file " + viper.ConfigFileUsed() + ". Have you called the login command? ")
 	}
 
 	if requireToken {

--- a/cmd/healthcheck.go
+++ b/cmd/healthcheck.go
@@ -69,6 +69,10 @@ func newHealthcheckCmd() *cobra.Command {
 				return checkConfigFile(false)
 			} else {
 				var err error
+				// strip any trailing slashes from the url
+				f.url = strings.TrimRight(f.url, "/")
+				//strip any trailing /fmeserver from the url
+				f.url = strings.TrimSuffix(f.url, "/fmeserver")
 				url, err := url.ParseRequestURI(f.url)
 				if err != nil {
 					return fmt.Errorf(urlErrorMsg)

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -85,12 +85,14 @@ func newLoginCmd() *cobra.Command {
 
 			// strip an trailing forward slashes from args[0]
 			args[0] = strings.TrimRight(args[0], "/")
+			// strip the /fmeserver from the end of the URL
+			args[0] = strings.TrimSuffix(args[0], "/fmeserver")
 
 			url, err := url.ParseRequestURI(args[0])
 			if err != nil {
 				return fmt.Errorf(urlErrorMsg)
 			}
-			if url.Path != "" && url.Path != "/fmeserver" {
+			if url.Path != "" {
 				return fmt.Errorf(urlErrorMsg)
 			}
 			return nil

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -50,7 +50,7 @@ type loginFlags struct {
 	expiration   int
 }
 
-var urlErrorMsg = "invalid FME Server URL specified. URL should be of the form https://myfmeflowhostname.com"
+var urlErrorMsg = "invalid FME Flow URL specified. URL should be of the form https://myfmeflowhostname.com"
 
 func newLoginCmd() *cobra.Command {
 	f := loginFlags{}
@@ -83,11 +83,14 @@ func newLoginCmd() *cobra.Command {
 				return fmt.Errorf("accepts at most 1 argument, received %d", len(args))
 			}
 
+			// strip an trailing forward slashes from args[0]
+			args[0] = strings.TrimRight(args[0], "/")
+
 			url, err := url.ParseRequestURI(args[0])
 			if err != nil {
 				return fmt.Errorf(urlErrorMsg)
 			}
-			if url.Path != "" {
+			if url.Path != "" && url.Path != "/fmeserver" {
 				return fmt.Errorf(urlErrorMsg)
 			}
 			return nil


### PR DESCRIPTION
This will allow trailing slashes and `/fmeserver` on the end of the URL. We will just strip it off and store it how we want it.