### PR TITLE
Update Flow REST API V4 calls in CLI to remove trailing slashes due to Spring 6 upgrade

### DIFF
--- a/cmd/requestfile_test.go
+++ b/cmd/requestfile_test.go
@@ -17,7 +17,7 @@ func TestLicenseRequestFile(t *testing.T) {
 		"fmeBuild": "FME Server 2023.0 - Build 23166 - linux-x64",
 		"code": "fc1e6bdd-3ccd-4749-a9aa-7f4ef9039c06",
 		"serialNumber": "AAAA-AAAA-AAAA",
-		"fmeServerUri": "https://somehost/fmerest/v3/",
+		"fmeServerUri": "https://somehost/fmerest/v3",
 		"industry": "Industry",
 		"publicIp": "127.0.0.1",
 		"subscribeToUpdates": false,


### PR DESCRIPTION
[FMEFLOWCLI-69]

Found and removed the only trailing slash occurrence at cmd\requestfile_test.go. Tested functionality after removing the / and everything works well.

[FMEFLOWCLI-69]: https://safesoftware.atlassian.net/browse/FMEFLOWCLI-69?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ