### PR TITLE
Fixes for release github action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -82,10 +82,6 @@ jobs:
       with:
         name: fmeflow-windows-amd64
     
-    #- name: Install Azure CLI
-    #  run: |
-    #    $ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest -Uri https://aka.ms/installazurecliwindows -OutFile .\AzureCLI.msi; Start-Process msiexec.exe -Wait -ArgumentList '/I AzureCLI.msi /quiet'; Remove-Item .\AzureCLI.msi
-    
     - uses: azure/login@v2
       with:
         creds: ${{ secrets.AZURE_CREDENTIALS }}


### PR DESCRIPTION
- Fixes digital signing on Windows to use Azure Keyvault Certificate
- Bump versions of various actions
- Bump version of Mac we do the Mac signing on as the old version was deprecated