### PR TITLE
Update source-id and source-type descriptions and examples.

### DIFF
--- a/cmd/jobs.go
+++ b/cmd/jobs.go
@@ -132,12 +132,7 @@ func newJobsCmd() *cobra.Command {
 		Use:   "jobs",
 		Short: "Lists jobs on FME Server",
 		Long:  "Lists running, queued, and/or queued jobs on FME Server. Pass in a job id to get information on a specific job.",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if f.jobsSourceID != "" && f.jobsSourceType == "" {
-				return errors.New("--source-id requires --source-type to be specified")
-			}
-			return nil
-		},
+
 		Example: `
 
   # List all jobs (currently limited to the most recent 1000)
@@ -175,6 +170,9 @@ func newJobsCmd() *cobra.Command {
 		PreRun: func(cmd *cobra.Command, args []string) {
 			if f.jobsWorkspace != "" {
 				cmd.MarkFlagRequired("repository")
+			}
+			if f.jobsSourceID != "" {
+				cmd.MarkFlagRequired("source-type")
 			}
 		},
 		RunE: jobsRun(&f),

--- a/cmd/jobs_v3_test.go
+++ b/cmd/jobs_v3_test.go
@@ -595,8 +595,8 @@ func TestJobs(t *testing.T) {
 		{
 			name:           "get jobs by source id",
 			statusCode:     http.StatusOK,
-			args:           []string{"jobs", "--source-id", "some-source-id"},
-			wantFormParams: map[string]string{"sourceID": "some-source-id"},
+			args:           []string{"jobs", "--source-id", "63f2489a-f3fc-4fa0-8df8-198de602b922", "--source-type", "Automations"},
+			wantFormParams: map[string]string{"sourceID": "63f2489a-f3fc-4fa0-8df8-198de602b922"},
 			fmeflowBuild:   24733, // Force V3 API usage (<= 25208 threshold)
 			body:           responseV3Completed,
 		},

--- a/cmd/jobs_v4_test.go
+++ b/cmd/jobs_v4_test.go
@@ -401,10 +401,18 @@ func TestJobsV4(t *testing.T) {
 		{
 			name:           "get jobs v4 by source-id",
 			statusCode:     http.StatusOK,
-			args:           []string{"jobs", "--source-id", "some-source-id"},
-			wantFormParams: map[string]string{"sourceID": "some-source-id"},
+			args:           []string{"jobs", "--source-id", "63f2489a-f3fc-4fa0-8df8-198de602b922", "--source-type", "automations"},
+			wantFormParams: map[string]string{"sourceID": "63f2489a-f3fc-4fa0-8df8-198de602b922"},
 			body:           responseV4Active,
 			fmeflowBuild:   25300,
+		},
+		{
+			name:         "get jobs v4 by source-id no source-type",
+			statusCode:   http.StatusOK,
+			args:         []string{"jobs", "--source-id", "63f2489a-f3fc-4fa0-8df8-198de602b922"},
+			wantErrText:  "required flag(s) \"source-type\" not set",
+			body:         responseV4Active,
+			fmeflowBuild: 25300,
 		},
 		{
 			name:           "get jobs v4 success and failure json",


### PR DESCRIPTION
Attempting to bring a bit more clarity to the source-id flag in the jobs command. In V4, the source-id is always the id (uuid) of the source.